### PR TITLE
product card widget overflow error fixed

### DIFF
--- a/lib/home/widgets/product_card.dart
+++ b/lib/home/widgets/product_card.dart
@@ -7,7 +7,8 @@ class ProductCard extends StatelessWidget {
   final String category;
   final String description;
 
-  ProductCard({
+  const ProductCard({
+    super.key,
     required this.title,
     required this.imageUrl,
     required this.price,
@@ -22,40 +23,74 @@ class ProductCard extends StatelessWidget {
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(10),
       ),
-      child: Container(
-        height: 300,
-        width: 300,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Image.network(imageUrl, fit: BoxFit.cover, height: 50, width: double.infinity),
-            Padding(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          AspectRatio(
+            aspectRatio: 16 / 9,
+            child: ClipRRect(
+              borderRadius:
+                  const BorderRadius.vertical(top: Radius.circular(10)),
+              child: Image.network(
+                imageUrl,
+                fit: BoxFit.cover,
+                width: double.infinity,
+              ),
+            ),
+          ),
+          Expanded(
+            child: SingleChildScrollView(
               padding: const EdgeInsets.all(8.0),
-              child: Text(
-                title,
-                style: const TextStyle(fontWeight: FontWeight.bold,),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 12,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    description,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      fontWeight: FontWeight.normal,
+                      color: Colors.grey,
+                      fontSize: 10,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    '\$${price.toStringAsFixed(2)}',
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 12,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                    decoration: BoxDecoration(
+                      color: Colors.grey[200],
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Text(
+                      category,
+                      style: const TextStyle(fontSize: 10),
+                    ),
+                  ),
+                ],
               ),
             ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8.0),
-              child: Text(
-                description,maxLines: 2, overflow: TextOverflow.ellipsis,
-                style: const TextStyle(fontWeight: FontWeight.normal, color: Colors.grey,),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8.0),
-              child: Text('\$${price.toStringAsFixed(2)}'),
-            ),
-            Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: Chip(
-                label: Text(category),
-                backgroundColor: Colors.grey[200],
-              ),
-            ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -396,10 +396,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: a75f83f14ad81d5fe4b3319710b90dec37da0e22612326b696c9e1b8f34bbf48
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.0"
+    version: "14.2.1"
   watcher:
     dependency: transitive
     description:


### PR DESCRIPTION
### Issue: Nested Column in ProductCard

In the ProductCard, the Expanded widget is wrapping a Padding that contains another Column. The inner Column uses mainAxisSize: MainAxisSize.min, which attempts to keep its size minimal, but the outer Expanded expects the child to expand, potentially leading to layout conflicts if the content exceeds the available space.

### Solution:
Used a SingleChildScrollView inside the Expanded widget in the ProductCard to allow the content to scroll if it overflows.